### PR TITLE
Fix : Fixed some bugs relating chat history and pagination which data…

### DIFF
--- a/ReactChat.Infrastructure/Repositories/Message/MessageRepository.cs
+++ b/ReactChat.Infrastructure/Repositories/Message/MessageRepository.cs
@@ -21,7 +21,6 @@ namespace ReactChat.Infrastructure.Repositories.Message
                 .OrderByDescending(x => x.Id)
                 .Skip((pageNum - 1) * pageSize)
                 .Take(pageSize + 1) // Fetch one extra message to check if there are more
-                .OrderBy(x => x.Id)
                 .ToListAsync();
 
             bool hasMore = messages.Count > pageSize;

--- a/reactchat.client/src/components/privateChat/PrivateChat.tsx
+++ b/reactchat.client/src/components/privateChat/PrivateChat.tsx
@@ -74,6 +74,8 @@ const PrivateChat: React.FC = () => {
   const handleSendMessage = async (message: string) => {
     if (connection && message.trim()) {
       await connection.invoke("SendPrivateMessage", username, message);
+      const container = messageListRef.current;
+      if (container) container.scrollTop = container.scrollHeight;
     }
   };
 

--- a/reactchat.client/src/hooks/useChatConnection.ts
+++ b/reactchat.client/src/hooks/useChatConnection.ts
@@ -37,12 +37,12 @@ export const useChatConnection = (): [
       newConnection.on("ReceiveMessage", (sender: string, content: string) => {
         const isSender = sender === currentUser;
         setMessages((prevMessages) => [
-          ...prevMessages,
           {
             sender: isSender ? "You" : sender,
             content,
             type: isSender ? "sender" : "recipient",
           },
+          ...prevMessages,
         ]);
       });
 

--- a/reactchat.client/src/main.tsx
+++ b/reactchat.client/src/main.tsx
@@ -1,7 +1,10 @@
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { createRoot } from "react-dom/client";
+import React from "react";
+import "./index.css";
+import App from "./App.tsx";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
     <App />
-)
+  </React.StrictMode>
+);


### PR DESCRIPTION
… was showing in wrong order

Fix message order and add auto-scroll in chat

- Removed .OrderBy(x => x.Id) in MessageRepository.cs to prevent re-ordering after pagination.
- Added auto-scroll to bottom in handleSendMessage in PrivateChat.tsx.
- Corrected message order in setMessages in useChatConnection.ts.
- Reformatted imports and added React.StrictMode in main.tsx.