### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -38,6 +38,9 @@
 
 name: .NET Core Desktop
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/AmirHS76/ReactChat/security/code-scanning/2](https://github.com/AmirHS76/ReactChat/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow primarily involves building, testing, and restoring a .NET Core application, it does not appear to require any write permissions. The minimal permission of `contents: read` will suffice. This change will ensure that the workflow does not inadvertently inherit unnecessary write permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
